### PR TITLE
Update client.ts

### DIFF
--- a/frontend/client.ts
+++ b/frontend/client.ts
@@ -1,6 +1,6 @@
-import sanityClient from '@sanity/client'
+import { createClient } from '@sanity/client'
 
-export default sanityClient({
+export default createClient({
   projectId: 'your-project-id', // you can find this in sanity.json
   dataset: 'production', // or the name you chose in step 1
   useCdn: true // `false` if you want to ensure fresh data


### PR DESCRIPTION
The default export of @sanity/client has been deprecated. Use the named export `createClient` instead.